### PR TITLE
Added support for {{comment}} and {{function_prefix}} to prompts

### DIFF
--- a/interview-oobabooga.py
+++ b/interview-oobabooga.py
@@ -11,6 +11,7 @@ parser = argparse.ArgumentParser(description='Interview executor for Kobold API 
 parser.add_argument('--questions', type=str, required=True, help='path to questions .csv from prepare stage')
 parser.add_argument('--outdir', type=str, required=True, help='output directory')
 parser.add_argument('--prompt', type=str, required=True, help="prompt template")
+parser.add_argument('--debug', action='store_true', help="store sent requests alongside responses")
 parser.add_argument('--host', type=str, default='localhost:5000', help="host to connect to")
 parser.add_argument('--config', type=str,  default='model_parameters/default.json', help=".json file with model parameters")
 args = parser.parse_args()
@@ -25,13 +26,24 @@ def send_request(prompt):
     response = requests.post(URI, json=request)    
     assert response.status_code == 200, response.content
     result = response.json()['results'][0]['text']
-    return result 
+    if args.debug:
+        print(json.dumps(request, indent=2))
+    return request, result
 
 def run():
     Path(args.outdir).mkdir(exist_ok=True, parents=True)
 
     with open(args.prompt) as f:
         prompt_template = Template(f.read())
+
+    comment = {
+        'python': '#',
+        'javascript': '//'
+    }
+    function_prefix = {
+        'python': 'def',
+        'javascript': 'function'
+    }
 
     df = pd.read_csv(args.questions)
     for idx, test in df.iterrows():
@@ -42,12 +54,21 @@ def run():
             print('Skipping, already exists')
             continue
 
-        full_prompt = prompt_template.render(prompt=test['prompt'])
-        answer = send_request(full_prompt)
+        full_prompt = prompt_template.render(
+                prompt=test['prompt'],
+                language=test['language'],
+                comment=comment[test['language']],
+                function_prefix=comment[test['language']]
+        )
+        request, answer = send_request(full_prompt)
         print(answer)
 
         with open(out_file, 'w') as f:
             f.write(answer)
+
+        if args.debug:
+            with open(f'{out_file}.request.json', 'w') as f:
+                f.write(json.dumps(request))
 
 if __name__ == "__main__":
     run()

--- a/interview-oobabooga.py
+++ b/interview-oobabooga.py
@@ -58,7 +58,7 @@ def run():
                 prompt=test['prompt'],
                 language=test['language'],
                 comment=comment[test['language']],
-                function_prefix=comment[test['language']]
+                function_prefix=function_prefix[test['language']]
         )
         request, answer = send_request(full_prompt)
         print(answer)

--- a/prompts/codet5p.txt
+++ b/prompts/codet5p.txt
@@ -1,0 +1,2 @@
+{{comment}} Let's {{prompt}}
+{{function_prefix}} 


### PR DESCRIPTION
This allow to test non-instruct models, but models that are aimed for completing the code.

Basic idea is that instead of prompt "Write a function that returns 5" for such models we can do 

```
# Let's  Write a function that returns 5
def 
```
which is more natural for them, because that's what they were trained on. 

I added example codet5p prompt, however at least 2B version doesn't work with oobabooga well.  
I tested it directly with `model(**tokenizer.encode())` and it was much better, so maybe current API settings are not that good for code completition. Or maybe I've used better prompts.

(Maybe prompts should not be in instruct format)
